### PR TITLE
Login with Openfire server

### DIFF
--- a/DXMPP/Connection.cpp
+++ b/DXMPP/Connection.cpp
@@ -51,13 +51,13 @@ else std::cout
         CurrentConnectionState = ConnectionState::WaitingForFeatures;
 
         stringstream Stream;
-        Stream << "<?xml version='1.0' encoding='utf-8'?>" << std::endl;
-        Stream << "<stream:stream" << endl;
-        Stream << " from = '" << MyJID.GetBareJID() << "'" << endl;
-        Stream << " to = '" << MyJID.GetDomain() << "'" << endl;
-        Stream << " version='1.0'" << endl;
-        Stream << " xml:lang='en'" << endl;
-        Stream << " xmlns='jabber:client'" << endl;
+        Stream << "<?xml version='1.0' encoding='utf-8'?>";
+        Stream << "<stream:stream";
+        Stream << " from = '" << MyJID.GetBareJID() << "'";
+        Stream << " to = '" << MyJID.GetDomain() << "'";
+        Stream << " version='1.0'";
+        Stream << " xml:lang='en'";
+        Stream << " xmlns='jabber:client'";
         Stream << " xmlns:stream='http://etherx.jabber.org/streams'>";
 
         DebugOut(DebugOutputTreshold::Debug)

--- a/DXMPP/SASL/SASLMechanism.cpp
+++ b/DXMPP/SASL/SASLMechanism.cpp
@@ -53,7 +53,7 @@ namespace DXMPP
         using namespace boost::archive::iterators;
 
         typedef transform_width< binary_from_base64<remove_whitespace<string::const_iterator> >, 8, 6 > Base64Decode;
-        typedef insert_linebreaks<base64_from_binary<transform_width<string::const_iterator,6,8> >, 72 > Base64Encode;
+        typedef base64_from_binary<transform_width<string::const_iterator,6,8> > Base64Encode;
 
         string SASLMechanism::DecodeBase64(string Input)
         {


### PR DESCRIPTION
``void Connection::OpenXMPPStream()`` send ``<stream:stream ...>`` with several ``std::endl``, that failed the communication with then Openfire server, block there and no any response before timeout, remove these ``\n`` can fix it

``insert_linebreaks`` cause ``incorrect-encoding`` on challenge response (base64 encoded), without linebreaks can success the authentication