### PR TITLE
C++17 build fixes, Crypto++

### DIFF
--- a/DXMPP/SASL/CryptoPP_byte.hpp
+++ b/DXMPP/SASL/CryptoPP_byte.hpp
@@ -1,0 +1,17 @@
+//
+//  CryptoPP_byte.cpp
+//  DXMPP
+//
+//  Created by Stefan Marton 2020
+//  Copyright (c) 2014 Deus ex Machinae. All rights reserved.
+//
+
+// Work around Crypto++ API incompatibility between 5.x and later versions
+
+#include <cryptopp/config.h>
+
+#if (CRYPTOPP_VERSION < 600)
+namespace CryptoPP {
+  typedef unsigned char byte;
+}
+#endif

--- a/DXMPP/SASL/SASLMechanism_DIGEST_MD5.cpp
+++ b/DXMPP/SASL/SASLMechanism_DIGEST_MD5.cpp
@@ -38,6 +38,7 @@
 
 #include "SaslChallengeParser.hpp"
 
+#include "CryptoPP_byte.hpp"
 
 namespace DXMPP
 {
@@ -58,7 +59,7 @@ namespace DXMPP
             string SASL_Mechanism_DigestMD5::GetMD5Hex(string Input)
             {
                 CryptoPP::Weak::MD5 hash;
-                byte digest[ CryptoPP::Weak::MD5::DIGESTSIZE ];
+                CryptoPP::byte digest[ CryptoPP::Weak::MD5::DIGESTSIZE ];
                 int length =CryptoPP::Weak::MD5::DIGESTSIZE;
                 
                 CryptoPP::HexEncoder Hexit;
@@ -78,7 +79,7 @@ namespace DXMPP
             string SASL_Mechanism_DigestMD5::GetHA1(string X, string nonce, string cnonce)
             {
                 CryptoPP::Weak::MD5 hash;
-                byte digest[ CryptoPP::Weak::MD5::DIGESTSIZE ];
+                CryptoPP::byte digest[ CryptoPP::Weak::MD5::DIGESTSIZE ];
                 int digestlength =CryptoPP::Weak::MD5::DIGESTSIZE;
     
                 // Calculatey Y
@@ -91,7 +92,7 @@ namespace DXMPP
                 TStream << ":" << nonce << ":" << cnonce;
                 string AuthentiationDetails = TStream.str();
                 int TLen = (int)digestlength + (int)AuthentiationDetails.length();
-                byte *T = new byte[TLen];
+                CryptoPP::byte *T = new CryptoPP::byte[TLen];
                 memcpy(T, digest, digestlength);
                 memcpy(T+digestlength, AuthentiationDetails.c_str(), AuthentiationDetails.length());
                 hash.CalculateDigest( digest, reinterpret_cast<const unsigned char *>( T ), TLen );

--- a/DXMPP/SASL/SASLMechanism_DIGEST_MD5.cpp
+++ b/DXMPP/SASL/SASLMechanism_DIGEST_MD5.cpp
@@ -38,13 +38,14 @@
 
 #include "SaslChallengeParser.hpp"
 
-using namespace std;
-using namespace pugi;
 
 namespace DXMPP
 {
     namespace SASL
     {
+        using namespace std;
+        using namespace pugi;
+
         namespace Weak
         {
             void SASL_Mechanism_DigestMD5::Begin()

--- a/DXMPP/SASL/SASLMechanism_DIGEST_MD5.hpp
+++ b/DXMPP/SASL/SASLMechanism_DIGEST_MD5.hpp
@@ -13,10 +13,6 @@
 
 namespace DXMPP
 {
-#if defined(CRYPTOPP_NO_GLOBAL_BYTE)
-  using CryptoPP::byte;
-#endif
-
     namespace SASL
     {
         namespace Weak

--- a/DXMPP/SASL/SASLMechanism_EXTERNAL.cpp
+++ b/DXMPP/SASL/SASLMechanism_EXTERNAL.cpp
@@ -43,12 +43,12 @@
 
 #include "SaslChallengeParser.hpp"
 
-using namespace std;
-
 namespace DXMPP
 {
     namespace SASL
     {
+        using namespace std;
+
         void SASL_Mechanism_EXTERNAL::Begin()
         {
 

--- a/DXMPP/SASL/SASLMechanism_PLAIN.cpp
+++ b/DXMPP/SASL/SASLMechanism_PLAIN.cpp
@@ -43,14 +43,11 @@
 
 #include "SaslChallengeParser.hpp"
 
+#include "CryptoPP_byte.hpp"
 
 
 namespace DXMPP
 {
-#if defined(CRYPTOPP_NO_GLOBAL_BYTE)
-  using CryptoPP::byte;
-#endif
-
     namespace SASL
     {
         using namespace std;
@@ -62,7 +59,7 @@ namespace DXMPP
                 std::string authid = MyJID.GetUsername();
                 std::string authzid = "";
     
-                byte tempbuff[1024];
+                CryptoPP::byte tempbuff[1024];
                 int offset= 0;
                 memcpy(tempbuff+offset, authzid.c_str(), authzid.length());
                 offset+=authzid.length();

--- a/DXMPP/SASL/SASLMechanism_PLAIN.cpp
+++ b/DXMPP/SASL/SASLMechanism_PLAIN.cpp
@@ -43,7 +43,6 @@
 
 #include "SaslChallengeParser.hpp"
 
-using namespace std;
 
 
 namespace DXMPP
@@ -52,8 +51,10 @@ namespace DXMPP
   using CryptoPP::byte;
 #endif
 
-namespace SASL
+    namespace SASL
     {
+        using namespace std;
+
         namespace Weak
         {
             void SASL_Mechanism_PLAIN::Begin()

--- a/DXMPP/SASL/SASLMechanism_SCRAM_SHA1.cpp
+++ b/DXMPP/SASL/SASLMechanism_SCRAM_SHA1.cpp
@@ -42,12 +42,12 @@
 
 #include "SaslChallengeParser.hpp"
 
-using namespace std;
-
 namespace DXMPP
 {
     namespace SASL
     {
+        using namespace std;
+
         void SASL_Mechanism_SCRAM_SHA1::Begin()
         {
             stringstream TStream;

--- a/DXMPP/SASL/SASLMechanism_SCRAM_SHA1.cpp
+++ b/DXMPP/SASL/SASLMechanism_SCRAM_SHA1.cpp
@@ -42,6 +42,8 @@
 
 #include "SaslChallengeParser.hpp"
 
+#include "CryptoPP_byte.hpp"
+
 namespace DXMPP
 {
     namespace SASL
@@ -80,10 +82,10 @@ namespace DXMPP
 
             string n = MyJID.GetUsername();
 
-            byte SaltBytes[1024];
+            CryptoPP::byte SaltBytes[1024];
 
             CryptoPP::Base64Decoder decoder;
-            decoder.Put((byte*)s.c_str(), s.length());
+            decoder.Put((CryptoPP::byte*)s.c_str(), s.length());
             decoder.MessageEnd();
 
             int SaltLength =decoder.Get(SaltBytes, 1024-4);
@@ -96,20 +98,20 @@ namespace DXMPP
             string p= ""; // proof!! calcualte!!
 
 
-            byte Result[ SHAVersion::DIGESTSIZE ];
-            byte tmp[ SHAVersion::DIGESTSIZE ];
-            byte ClientKey[ SHAVersion::DIGESTSIZE ];
-            byte StoredKey[ SHAVersion::DIGESTSIZE ];
-            byte Previous[ SHAVersion::DIGESTSIZE ];
-            byte ClientSignature[ SHAVersion::DIGESTSIZE ];
-            byte ClientProof[ SHAVersion::DIGESTSIZE ];
-            byte ServerKey[ SHAVersion::DIGESTSIZE ];
-            byte ServerSignature[SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte Result[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte tmp[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte ClientKey[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte StoredKey[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte Previous[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte ClientSignature[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte ClientProof[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte ServerKey[ SHAVersion::DIGESTSIZE ];
+            CryptoPP::byte ServerSignature[SHAVersion::DIGESTSIZE ];
 
             int digestlength =SHAVersion::DIGESTSIZE;
 
             // Calculate Result
-            CryptoPP::HMAC< SHAVersion > hmacFromPassword((byte*)Password.c_str(),
+            CryptoPP::HMAC< SHAVersion > hmacFromPassword((CryptoPP::byte*)Password.c_str(),
                                                           Password.length());
             hmacFromPassword.CalculateDigest( Result, SaltBytes, SaltLength);
 
@@ -127,7 +129,7 @@ namespace DXMPP
             // Result is now salted password
             CryptoPP::HMAC< SHAVersion > hmacFromSaltedPassword(Result, digestlength);
             hmacFromSaltedPassword.CalculateDigest( ClientKey,
-                                                    (byte*)"Client Key",
+                                                    (CryptoPP::byte*)"Client Key",
                                                     strlen("Client Key"));
 
             SHAVersion hash;
@@ -143,7 +145,7 @@ namespace DXMPP
 
             CryptoPP::HMAC< SHAVersion > hmacFromStoredKey(StoredKey, digestlength);
             hmacFromStoredKey.CalculateDigest( ClientSignature,
-                                               (byte*)AuthMessage.c_str(),
+                                               (CryptoPP::byte*)AuthMessage.c_str(),
                                                AuthMessage.length());
 
             for(int i = 0; i < digestlength; i++)
@@ -153,12 +155,12 @@ namespace DXMPP
 
             // Prepare an HMAC SHA-1 digester using the salted password bytes as the key.
             hmacFromSaltedPassword.CalculateDigest( ServerKey,
-                                                    (byte*)"Server Key",
+                                                    (CryptoPP::byte*)"Server Key",
                                                     strlen("Server Key"));
 
             CryptoPP::HMAC< SHAVersion > hmacFromServerKey(ServerKey, digestlength);
             hmacFromServerKey.CalculateDigest( ServerSignature,
-                                               (byte*)AuthMessage.c_str(),
+                                               (CryptoPP::byte*)AuthMessage.c_str(),
                                                AuthMessage.length());
             CryptoPP::ArraySource(ServerSignature, digestlength, true,
                                         new CryptoPP::Base64Encoder(

--- a/DXMPP/SASL/SASLMechanism_SCRAM_SHA1.hpp
+++ b/DXMPP/SASL/SASLMechanism_SCRAM_SHA1.hpp
@@ -16,11 +16,6 @@
 
 namespace DXMPP
 {
-
-#if defined(CRYPTOPP_NO_GLOBAL_BYTE)
-  using CryptoPP::byte;
-#endif
-
     namespace SASL
     {
         typedef CryptoPP::SHA1 SHAVersion; // CryptoPP::SHA256


### PR DESCRIPTION
Resolves issues with use of the type 'byte' in global namespace, from Crypto++ versions < 6.0, which was ambiguous with std::byte introduced in C++17 in some circumstances.
